### PR TITLE
Change scheduler random_interval_max to 2 min for testnet

### DIFF
--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -7,11 +7,15 @@ from models import Transient
 from misc import printdbg
 import time
 import random
+import config
 
 
 class Scheduler(object):
     transient_key_scheduled = 'NEXT_SENTINEL_CHECK_AT'
-    random_interval_max = 1800
+    if config.network == 'testnet':
+        random_interval_max = 120
+    else:  
+        random_interval_max = 1800
 
     @classmethod
     def is_run_time(self):


### PR DESCRIPTION
This will make Sentinel more responsive since the superblock cycle is so short on Testnet (10 blocks).